### PR TITLE
Fix error on pyahocorasick install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
 
+RUN apt-get update && apt-get -y install build-essential
+
 # Install pip requirements
 COPY requirements.txt .
 RUN python -m pip install -r requirements.txt


### PR DESCRIPTION
Ajouter le package build-essential avec apt semble me permettre de faire l'install du package pip