### PR TITLE
Add /technologies route

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from nlp.nlp import NaturalLanguageProcessor
 from src.config_parameters.cassandra.fetch_cassandra_parameters import \
     find_parameter
 from src.SO.answers import get_answers
+from src.config_parameters.technologies import get_all_technologies
 
 # Path to the pre-trained model
 MODEL_PATH = "./BD/model.pickle"
@@ -48,6 +49,18 @@ def answers(question_id: int) -> Response:
     print(f"GET /answers/{question_id}")
     answers = get_answers(question_id)
     return jsonify(answers)
+
+
+@app.route("/technologies", methods=['GET'])
+def technologies() -> Response:
+    """Fetches all available technologies to search from.
+
+    Returns:
+        Response: List of technologies.
+    """
+    print(f"GET /technologies")
+    technologies = get_all_technologies()
+    return jsonify(technologies)
 
 
 @app.route("/search", methods=['GET'])

--- a/src/config_parameters/technologies.py
+++ b/src/config_parameters/technologies.py
@@ -1,0 +1,21 @@
+import os
+
+TECHNOLOGIES_PATH = "./src/config_parameters"
+
+
+def get_all_technologies() -> list:
+    """
+    Gets all available technologies based on the directory structure. 
+    exclude the __pycache__ directory
+
+    Returns:
+        list: list of technologies available
+    """
+    technologies = [
+        directory for directory in os.listdir(TECHNOLOGIES_PATH)
+        if (os.path.isdir(os.path.join(TECHNOLOGIES_PATH, directory)) and directory != "__pycache__")
+    ]
+
+    return list(map(
+        lambda x: {"key": x, "value": x},
+        technologies))


### PR DESCRIPTION
Retourne la liste des technologies disponibles basé sur les directory dans `./src/config_parameters`. La liste va donc automatiquement inclure les nouvelles technologies lorsqu'on ajoute un nouveau dossier avec les nouveaux paramètres.

`GET /technologies`
```json
[
    {
        "key": "cassandra",
        "value": "cassandra"
    },
    {
        "key": "docker",
        "value": "docker"
    }
]
```